### PR TITLE
Implement retry_max; update schema docs

### DIFF
--- a/desec/provider.go
+++ b/desec/provider.go
@@ -36,6 +36,11 @@ func Provider() *schema.Provider {
 				Description:  "The API token for operations.",
 				ValidateFunc: validation.StringMatch(regexp.MustCompile("[0-9a-zA-Z_-]{28}"), "API key looks invalid"),
 			},
+			"retry_max": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Description:  "The max number of retries when sending an API request.",
+			},
 		},
 		ResourcesMap: map[string]*schema.Resource{
 			"desec_rrset":  resourceRRSet(),
@@ -55,6 +60,11 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	o.HTTPClient = cleanhttp.DefaultClient()
 	o.HTTPClient.Transport = logging.NewTransport("Desec", o.HTTPClient.Transport)
 	o.Logger = log.Default()
+
+        retry_max, retry_max_set := d.GetOk("retry_max")
+        if retry_max_set {
+                o.RetryMax = retry_max.(int)
+        }
 
 	c := dsc.New(token, o)
 	api_uri := d.Get("api_uri").(string)

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,6 +23,3 @@ provider "desec" {
 
 - **api_token** (String) API token to authenticate to the service.
 - **api_uri** (String, Optional) The API base URI to use. Defaults to `https://desec.io/api/v1/`
-- **limit_read** (Integer, Optional) Maximum number of read API requests to send, per second. Defaults to 8.
-- **limit_write** (Integer, Optional) Maximum number of write API requests to send, per second. Defaults to 5.
-

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,3 +23,4 @@ provider "desec" {
 
 - **api_token** (String) API token to authenticate to the service.
 - **api_uri** (String, Optional) The API base URI to use. Defaults to `https://desec.io/api/v1/`
+- **retry_max** (Integer, Optional) The max number of retries when sending an API request. The default value is determined by the deSEC API client [implementation](https://github.com/nrdcg/desec).


### PR DESCRIPTION
- Fix the schema documentation: remove the mentions of the obsolete arguments `limit_read` and `limit_write`.
- Implement one of the enhancements suggested in https://github.com/Valodim/terraform-provider-desec/issues/7: expose the [`RetryMax`](https://github.com/nrdcg/desec/blob/401c94cfb8e86b664e0d3ddcb5785fa15ea44b16/desec.go#L32) option of the deSEC API client as `retry_max` (Integer) &mdash; an optional schema argument. The default value is determined by the `desec` module (5 at the moment).