### PR TITLE
allow TTL of 60 and higher

### DIFF
--- a/desec/resource_rrset.go
+++ b/desec/resource_rrset.go
@@ -72,7 +72,7 @@ func resourceRRSet() *schema.Resource {
 			"ttl": {
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(3600, 604800),
+				ValidateFunc: validation.IntBetween(60, 604800),
 			},
 		},
 	}


### PR DESCRIPTION
Hi, desec.io allows a TTL lower than 3600, so we should not block these generally. I just set the validation to 60, cause I think that this is the lowest desec allows.

With the proposed solution if you set a wrong TTL it will just fail with:
```
Error: 400: body: {"ttl":["Ensure this value is greater than or equal to 3600."]}
 
  with desec_rrset.testl_a,
  on main.tf line 41, in resource "desec_rrset" "test_a":
  41: resource "desec_rrset" "test_a" {
```
Another option would be to get the allowed TTL from desec and then check for that. 