### PR TITLE
add flake.nix with flake-parts for Nix packaging

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,7 @@
 # This file is relevant for users of Nix: You can use direnv to automatically
 # set up the dev environment while in this directory.
 # See also: https://direnv.net/ and https://github.com/nix-community/nix-direnv
-use nix
+use flake
 
 # load variables from .env, if it exists
 dotenv_if_exists

--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,8 @@ dist
 
 .env
 
+# Nix
+.direnv/
+result
+
 dist/

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,18 @@
+{
+  lib,
+  buildGoModule,
+}:
+buildGoModule {
+  pname = "terraform-provider-desec";
+  version = "0.6.1";
+
+  src = ./.;
+  vendorHash = "sha256-APeSigqPXoAoPLmC9YCRIfo0vkChzHQocqM3LqoA1/w=";
+
+  meta = {
+    description = "Terraform/OpenTofu provider for deSEC DNS";
+    homepage = "https://github.com/Valodim/terraform-provider-desec";
+    license = lib.licenses.mpl20;
+    mainProgram = "terraform-provider-desec";
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1772408722,
+        "narHash": "sha256-rHuJtdcOjK7rAHpHphUb1iCvgkU3GpfvicLMwwnfMT0=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f20dc5d9b8027381c474144ecabc9034d6a839a3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1772328832,
+        "narHash": "sha256-e+/T/pmEkLP6BHhYjx6GmwP5ivonQQn0bJdH9YrRB+Q=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "c185c7a5e5dd8f9add5b2f8ebeff00888b070742",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,27 @@
+{
+  description = "Terraform/OpenTofu provider for deSEC DNS";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+  };
+
+  outputs = inputs @ {flake-parts, ...}:
+    flake-parts.lib.mkFlake {inherit inputs;} {
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+
+      perSystem = {pkgs, ...}: let
+        pkg = pkgs.callPackage ./default.nix {};
+      in {
+        packages.default = pkg;
+        packages.terraform-provider-desec = pkg;
+
+        devShells.default = pkgs.callPackage ./shell.nix {};
+      };
+    };
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,15 +1,8 @@
-let
-  pkgs = import <nixpkgs> {
-    overlays = [
-      # for pinning specific versions (currently not needed)
-      # (self: super: { nodejs = self.nodejs-12_x; })
-    ];
-};
-in
-  pkgs.mkShell {
-    buildInputs = with pkgs; [
-      go
-      goreleaser
-      opentofu
-    ];
-  }
+{pkgs ? import <nixpkgs> {}}:
+pkgs.mkShell {
+  buildInputs = with pkgs; [
+    go
+    goreleaser
+    opentofu
+  ];
+}


### PR DESCRIPTION
Adds a Nix flake that exports the provider as the default package (via default.nix) and a devShell (via shell.nix). Updates .envrc to use `use flake` and .gitignore for Nix artifacts.